### PR TITLE
Build/CI: Add base nix build for cross compiles from linux

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ obj/
 *.opensdf
 *.sln.docstates
 
+# Zed files
+.zed/
+
 # NuGet packages
 *.nupkg
 packages/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ _ReSharper*/
 artifacts/
 # Scanner configuration file (user-specific)
 scan_config.ini
+
+result
+out
+.direnv

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,17 @@
+{
+  "lsp": {
+    "roslyn": {
+      "binary": {
+        "path": "csharp-ls",
+        "arguments": ["-s", "BFD9010/BFD9010.sln"],
+        "env": {
+          "RuntimeIdentifier": "win-x86",
+          "PlatformTarget": "x86",
+          "TargetPlatformIdentifier": "Windows",
+          "TargetPlatformMinVersion": "7.0",
+          "EnableKnownPlatformsReference": "true",
+        },
+      },
+    },
+  },
+}

--- a/BFD9010/BFD9010.Cli/BFD9010.Cli.csproj
+++ b/BFD9010/BFD9010.Cli/BFD9010.Cli.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Platforms>AnyCPU;x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
     <AssemblyName>bfd9010_cli</AssemblyName>
   </PropertyGroup>

--- a/BFD9010/BFD9010.FhirApi.Tests/BFD9010.FhirApi.Tests.csproj
+++ b/BFD9010/BFD9010.FhirApi.Tests/BFD9010.FhirApi.Tests.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Platforms>AnyCPU;x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/BFD9010/BFD9010.FhirApi/BFD9010.FhirApi.csproj
+++ b/BFD9010/BFD9010.FhirApi/BFD9010.FhirApi.csproj
@@ -1,18 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Platforms>AnyCPU;x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Hl7.Fhir.R5" Version="5.12.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference
+            Include="Microsoft.Extensions.Logging.Abstractions"
+            Version="8.0.0"
+        />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/BFD9010/BFD9010.Gui/BFD9010.Gui.csproj
+++ b/BFD9010/BFD9010.Gui/BFD9010.Gui.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>bfd9010</AssemblyName>
     <Platforms>AnyCPU;x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ApplicationIcon>..\..\documentation\images\BFD9000_logo_white.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/BFD9010/BFD9010.Gui/BFD9010.Gui.csproj
+++ b/BFD9010/BFD9010.Gui/BFD9010.Gui.csproj
@@ -7,20 +7,24 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>bfd9010</AssemblyName>
-    <Platforms>AnyCPU;x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <ApplicationIcon>..\..\documentation\images\BFD9000_logo_white.ico</ApplicationIcon>
+    <ApplicationIcon
+        >..\..\documentation\images\BFD9000_logo_white.ico</ApplicationIcon>
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\..\documentation\images\BFD9000_logo_white.ico">
+    <EmbeddedResource
+            Include="..\..\documentation\images\BFD9000_logo_white.ico"
+        >
       <Link>Resources\BFD9000_logo_white.ico</Link>
     </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\..\documentation\images\BFD9000_logo_white.png">
+    <EmbeddedResource
+            Include="..\..\documentation\images\BFD9000_logo_white.png"
+        >
       <Link>Resources\BFD9000_logo_white.png</Link>
     </EmbeddedResource>
   </ItemGroup>

--- a/BFD9010/BFD9010.Scanner/BFD9010.Scanner.csproj
+++ b/BFD9010/BFD9010.Scanner/BFD9010.Scanner.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Platforms>AnyCPU;x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 

--- a/BFD9010/BFD9010.Scanner/ScanConfig.cs
+++ b/BFD9010/BFD9010.Scanner/ScanConfig.cs
@@ -8,7 +8,7 @@ namespace BFD9010.Scanner
     /// </summary>
     public class ScanConfig
     {
-        private const string CONFIG_FILENAME = "scan_config.ini";
+        private const string CONFIG_FILENAME = "~\\Desktop\\VidarScans\\scan_config.ini";
 
         // Scan parameters with their default values (from original code before PR)
         public short Offset0_BitDepth { get; set; } = 16;
@@ -296,9 +296,16 @@ namespace BFD9010.Scanner
 
         private static string GetConfigPath()
         {
-            // Place config file in the same directory as the executable
-            string exeDir = AppDomain.CurrentDomain.BaseDirectory;
-            return Path.Combine(exeDir, CONFIG_FILENAME);
+            string outDir = Environment.ExpandEnvironmentVariables(CONFIG_FILENAME);
+            if (outDir.StartsWith('~'))
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string rest = outDir.Length == 1 ? string.Empty : outDir.Substring(1).TrimStart('\\', '/');
+                outDir = Path.Combine(home, rest);
+            }
+            outDir = Path.GetFullPath(outDir);
+            Directory.CreateDirectory(Path.GetDirectoryName(outDir));
+            return outDir;
         }
 
         private static string ExpandPath(string path)

--- a/BFD9010/BFD9010.Scanner/ScanConfig.cs
+++ b/BFD9010/BFD9010.Scanner/ScanConfig.cs
@@ -8,7 +8,7 @@ namespace BFD9010.Scanner
     /// </summary>
     public class ScanConfig
     {
-        private const string CONFIG_FILENAME = "~\\Desktop\\VidarScans\\scan_config.ini";
+        private const string CONFIG_FILENAME = "scan_config.ini";
 
         // Scan parameters with their default values (from original code before PR)
         public short Offset0_BitDepth { get; set; } = 16;
@@ -296,16 +296,16 @@ namespace BFD9010.Scanner
 
         private static string GetConfigPath()
         {
-            string outDir = Environment.ExpandEnvironmentVariables(CONFIG_FILENAME);
-            if (outDir.StartsWith('~'))
-            {
-                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-                string rest = outDir.Length == 1 ? string.Empty : outDir.Substring(1).TrimStart('\\', '/');
-                outDir = Path.Combine(home, rest);
-            }
-            outDir = Path.GetFullPath(outDir);
-            Directory.CreateDirectory(Path.GetDirectoryName(outDir));
-            return outDir;
+            string outDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "VidarScans"
+            );
+            Directory.CreateDirectory(outDir);
+            string configPath = Path.Combine(
+                outDir,
+                CONFIG_FILENAME
+            );
+            return configPath;
         }
 
         private static string ExpandPath(string path)

--- a/BFD9010/Directory.Build.props
+++ b/BFD9010/Directory.Build.props
@@ -5,5 +5,8 @@
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <AssemblyInformationalVersion>$(Version)</AssemblyInformationalVersion>
+    <RestorePackagesPath>$(MSBuildThisFileDirectory)../.nuget/packages</RestorePackagesPath>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <DetermineReferencesFromSourceCache>true</DetermineReferencesFromSourceCache>
   </PropertyGroup>
 </Project>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,13 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+        dn = (
+          with pkgs.dotnetCorePackages;
+          combinePackages [
+            sdk_8_0
+            sdk_10_0
+          ]
+        );
       in
       {
         packages = rec {
@@ -32,15 +39,9 @@
             # Explicitly set runtimeId to null to block the host-side targeting pack additions
             runtimeId = null;
 
-            # Explicitly feed our win-x64 target down into the underlying NuGet fetcher mapping
-            # meta.platforms = [ "x86_64-windows" ];
-
             configurePhase = ''
               export HOME=$TMPDIR
               export DOTNET_CLI_HOME=$TMPDIR
-
-              # The addNuGetDeps hook outputs its organized cache folder to $nugetDeps
-              # We map the standard .NET environment variable straight to it
               export NUGET_PACKAGES=$nugetDeps
             '';
 
@@ -81,18 +82,17 @@
           app = pkgs.stdenv.mkDerivation (nugetDeps base);
         };
 
-        # Spin up a quick development shell with 'nix develop'
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            dotnetCorePackages.runtime_8_0
-            dotnetCorePackages.sdk_8_0
+            dn
             nuget-to-json
             nil
             nixd
+            csharp-ls
           ];
 
           shellHook = ''
-            export DOTNET_ROOT="${pkgs.dotnetCorePackages.sdk_10_0}/share/dotnet"
+            export DOTNET_ROOT="${dn}/share/dotnet"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,65 +21,9 @@
         );
       in
       {
-        packages = rec {
-          nugetDeps = pkgs.dotnetCorePackages.addNuGetDeps {
-            nugetDeps = ./nix/deps.json;
-          };
-          default = app;
-          base = {
-            pname = "BFD9010.Gui";
-            version = "1.0.0";
-            src = ./.;
-
-            nativeBuildInputs = [
-              pkgs.dotnetCorePackages.sdk_8_0
-              pkgs.cacert
-            ];
-
-            # Explicitly set runtimeId to null to block the host-side targeting pack additions
-            runtimeId = null;
-
-            configurePhase = ''
-              export HOME=$TMPDIR
-              export DOTNET_CLI_HOME=$TMPDIR
-              export NUGET_PACKAGES=$nugetDeps
-            '';
-
-            buildPhase = ''
-              # Pure offline compilation phase using only the decoupled Windows targets
-              dotnet restore BFD9010/BFD9010.Gui/BFD9010.Gui.csproj \
-                -r win-x86 \
-                --source "$nugetDeps" \
-                -p:EnableWindowsTargeting=true
-
-              dotnet publish BFD9010/BFD9010.Gui/BFD9010.Gui.csproj \
-                -c Release \
-                -r win-x86 \
-                --no-restore \
-                -p:TargetFramework=net8.0-windows \
-                --self-contained true \
-                -o $out/share/bfd9010
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-
-              cat <<EOF > $out/bin/bfd9010-server
-              #!/usr/bin/env bash
-              export WINEDEBUG=-all
-              export WINEARCH=win32
-                export WINEPREFIX=\$HOME/.local/share/bfd9010-wine
-                if [ ! -d "\$WINEPREFIX" ]; then
-                  echo "Initializing 32-bit Wine environment..."
-                  ${pkgs.wine}/bin/wineboot -u
-                fi
-              exec ${pkgs.wine}/bin/wine $out/share/bfd9010/bfd9010.exe "\$@"
-              EOF
-
-              chmod +x $out/bin/bfd9010-server
-            '';
-          };
-          app = pkgs.stdenv.mkDerivation (nugetDeps base);
+        packages = {
+          app = pkgs.callPackage ./nix/build.nix { };
+          default = pkgs.callPackage ./nix/build.nix { };
         };
 
         devShells.default = pkgs.mkShell {
@@ -89,12 +33,16 @@
             nil
             nixd
             csharp-ls
+            wine
           ];
 
           shellHook = ''
             export DOTNET_ROOT="${dn}/share/dotnet"
           '';
         };
+
+        # Cannot do windows checks on linux as we do not have the necessary 32-bit runtimes.
+        # Possible solution: run in a Windows VM to test
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "BFD9010: An HL7 FHIR API for Scanners";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages = rec {
+          nugetDeps = pkgs.dotnetCorePackages.addNuGetDeps {
+            nugetDeps = ./nix/deps.json;
+          };
+          default = app;
+          base = {
+            pname = "BFD9010.Gui";
+            version = "1.0.0";
+            src = ./.;
+
+            nativeBuildInputs = [
+              pkgs.dotnetCorePackages.sdk_8_0
+              pkgs.cacert
+            ];
+
+            # Explicitly set runtimeId to null to block the host-side targeting pack additions
+            runtimeId = null;
+
+            # Explicitly feed our win-x64 target down into the underlying NuGet fetcher mapping
+            # meta.platforms = [ "x86_64-windows" ];
+
+            configurePhase = ''
+              export HOME=$TMPDIR
+              export DOTNET_CLI_HOME=$TMPDIR
+
+              # The addNuGetDeps hook outputs its organized cache folder to $nugetDeps
+              # We map the standard .NET environment variable straight to it
+              export NUGET_PACKAGES=$nugetDeps
+            '';
+
+            buildPhase = ''
+              # Pure offline compilation phase using only the decoupled Windows targets
+              dotnet restore BFD9010/BFD9010.Gui/BFD9010.Gui.csproj \
+                -r win-x86 \
+                --source "$nugetDeps" \
+                -p:EnableWindowsTargeting=true
+
+              dotnet publish BFD9010/BFD9010.Gui/BFD9010.Gui.csproj \
+                -c Release \
+                -r win-x86 \
+                --no-restore \
+                -p:TargetFramework=net8.0-windows \
+                --self-contained true \
+                -o $out/share/bfd9010
+            '';
+
+            installPhase = ''
+              mkdir -p $out/bin
+
+              cat <<EOF > $out/bin/bfd9010-server
+              #!/usr/bin/env bash
+              export WINEDEBUG=-all
+              export WINEARCH=win32
+                export WINEPREFIX=\$HOME/.local/share/bfd9010-wine
+                if [ ! -d "\$WINEPREFIX" ]; then
+                  echo "Initializing 32-bit Wine environment..."
+                  ${pkgs.wine}/bin/wineboot -u
+                fi
+              exec ${pkgs.wine}/bin/wine $out/share/bfd9010/bfd9010.exe "\$@"
+              EOF
+
+              chmod +x $out/bin/bfd9010-server
+            '';
+          };
+          app = pkgs.stdenv.mkDerivation (nugetDeps base);
+        };
+
+        # Spin up a quick development shell with 'nix develop'
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            dotnetCorePackages.runtime_8_0
+            dotnetCorePackages.sdk_8_0
+            nuget-to-json
+            nil
+            nixd
+          ];
+
+          shellHook = ''
+            export DOTNET_ROOT="${pkgs.dotnetCorePackages.sdk_10_0}/share/dotnet"
+          '';
+        };
+      }
+    );
+}

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,0 +1,67 @@
+{
+  dotnetCorePackages,
+  cacert,
+  wine,
+  stdenv,
+  ...
+}:
+let
+  nugetDeps = dotnetCorePackages.addNuGetDeps {
+    nugetDeps = ../nix/deps.json;
+  };
+  base = {
+    pname = "BFD9010.Gui";
+    version = "1.0.0";
+    src = ./..;
+
+    nativeBuildInputs = [
+      dotnetCorePackages.sdk_8_0
+      cacert
+    ];
+
+    # Explicitly set runtimeId to null to block the host-side targeting pack additions
+    runtimeId = null;
+
+    configurePhase = ''
+      export HOME=$TMPDIR
+      export DOTNET_CLI_HOME=$TMPDIR
+      export NUGET_PACKAGES=$nugetDeps
+    '';
+
+    buildPhase = ''
+      # Pure offline compilation phase using only the decoupled Windows targets
+
+      dotnet restore BFD9010/BFD9010.Gui/BFD9010.Gui.csproj \
+        -r win-x86 \
+        --source "$nugetDeps" \
+        -p:EnableWindowsTargeting=true
+
+      dotnet publish BFD9010/BFD9010.Gui/BFD9010.Gui.csproj \
+        -c Release \
+        -r win-x86 \
+        --no-restore \
+        -p:TargetFramework=net8.0-windows \
+        --self-contained true \
+        -o $out/share/bfd9010
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+
+      cat <<EOF > $out/bin/bfd9010-server
+      #!/usr/bin/env bash
+      export WINEDEBUG=-all
+      export WINEARCH=win32
+        export WINEPREFIX=\$HOME/.local/share/bfd9010-wine
+        if [ ! -d "\$WINEPREFIX" ]; then
+          echo "Initializing 32-bit Wine environment..."
+          ${wine}/bin/wineboot -u
+        fi
+      exec ${wine}/bin/wine $out/share/bfd9010/bfd9010.exe "\$@"
+      EOF
+
+      chmod +x $out/bin/bfd9010-server
+    '';
+  };
+in
+stdenv.mkDerivation (nugetDeps base)

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,0 +1,727 @@
+[
+  {
+    "pname": "Castle.Core",
+    "version": "5.1.1",
+    "hash": "sha256-oVkQB+ON7S6Q27OhXrTLaxTL0kWB58HZaFFuiw4iTrE="
+  },
+  {
+    "pname": "coverlet.collector",
+    "version": "6.0.0",
+    "hash": "sha256-IEmweTMapcPhFHpmJsPXfmMhravYOrWupgjeOvMmQ4o="
+  },
+  {
+    "pname": "Fhir.Metrics",
+    "version": "1.3.1",
+    "hash": "sha256-bHv51AUyWAUn/AukcB4icB65vddDLxR5+QGnd43Qz2w="
+  },
+  {
+    "pname": "Hl7.Fhir.Base",
+    "version": "5.12.2",
+    "hash": "sha256-EbtO66N+864Q2nQO/v90FfWbbj2a61iFJ4V3lBxtcFQ="
+  },
+  {
+    "pname": "Hl7.Fhir.Conformance",
+    "version": "5.12.2",
+    "hash": "sha256-R78em2Mqlb2KA2E5ZT7DG0ITlO2grglC7shB6Zmwpyg="
+  },
+  {
+    "pname": "Hl7.Fhir.R5",
+    "version": "5.12.2",
+    "hash": "sha256-SW7mSv+gLCJ/iPZ5VW9CYUGLiNYXkNoLAOiBdX2SzbQ="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.win-x86",
+    "version": "8.0.27",
+    "hash": "sha256-ezmkuuRx5X3Jj+k4lAOVI/4A0Ko5KCaH3h+lyRE+QAU="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.OpenApi",
+    "version": "8.0.20",
+    "hash": "sha256-Fe8of7wvOn3d7ZaP3GMJIXxhjqX05qCylPIjBsw3HE8="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.8.0",
+    "hash": "sha256-cv/wAXfTNS+RWEsHWNKqRDHC7LOQSSdFJ1a9cZuSfJw="
+  },
+  {
+    "pname": "Microsoft.Extensions.ApiDescription.Server",
+    "version": "6.0.5",
+    "hash": "sha256-RJjBWz+UHxkQE2s7CeGYdTZ218mCufrxl0eBykZdIt4="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.8.0",
+    "hash": "sha256-uz7QvW+NsVRsp8FR1wjnGEOkUaPX4JyieywvCN6g2+s="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.win-x86",
+    "version": "8.0.27",
+    "hash": "sha256-3sPhI/cwhgVltKhte6D6TXf38qhYfz9NaLIvc+IjJIo="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.win-x86",
+    "version": "8.0.27",
+    "hash": "sha256-NHZl1Uu39QkqT1gT4DwlGU1M5bxMpKdYntB7eDSGXZA="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "1.4.3",
+    "hash": "sha256-vk47e78OwopXJx2LhDRbKFObqF3GShHfNHR2SzvbQeA="
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "1.6.14",
+    "hash": "sha256-dSJUic2orPGfYVgto9DieRckbtLpPyxHtf+RJ2tmKPM="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.8.0",
+    "hash": "sha256-9TwGrjVvbtyetw67Udp3EMK5MX8j0RFRjduxPCs9ESw="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.8.0",
+    "hash": "sha256-+CTYFu631uovLCO47RKe86YaAqfoLA4r73vKORJUsjg="
+  },
+  {
+    "pname": "Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg="
+  },
+  {
+    "pname": "Microsoft.WindowsDesktop.App.Ref",
+    "version": "8.0.27",
+    "hash": "sha256-Pi1DhrjL6Co82lAGUuFSM5MViM3DDCqzHhhoGX+wK4g="
+  },
+  {
+    "pname": "Microsoft.WindowsDesktop.App.Runtime.win-x86",
+    "version": "8.0.27",
+    "hash": "sha256-4hoShQ7+atWgO4YsB0nH5qCibIKxhyNmUD+mH+t8AxA="
+  },
+  {
+    "pname": "Moq",
+    "version": "4.20.72",
+    "hash": "sha256-+uAc/6xtzij9YnmZrhZwc+4vUgx6cppZsWQli3CGQ8o="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "1.6.1",
+    "hash": "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "NuGet.Frameworks",
+    "version": "6.5.0",
+    "hash": "sha256-ElqfN4CcKxT3hP2qvxxObb4mnBlYG89IMxO0Sm5oZ2g="
+  },
+  {
+    "pname": "runtime.any.System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8="
+  },
+  {
+    "pname": "runtime.any.System.Diagnostics.Tools",
+    "version": "4.3.0",
+    "hash": "sha256-8yLKFt2wQxkEf7fNfzB+cPUCjYn2qbqNgQ1+EeY2h/I="
+  },
+  {
+    "pname": "runtime.any.System.Diagnostics.Tracing",
+    "version": "4.3.0",
+    "hash": "sha256-dsmTLGvt8HqRkDWP8iKVXJCS+akAzENGXKPV18W2RgI="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Globalization.Calendars",
+    "version": "4.3.0",
+    "hash": "sha256-AYh39tgXJVFu8aLi9Y/4rK8yWMaza4S4eaxjfcuEEL4="
+  },
+  {
+    "pname": "runtime.any.System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE="
+  },
+  {
+    "pname": "runtime.any.System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-Y2AnhOcJwJVYv7Rp6Jz6ma0fpITFqJW+8rsw106K2X8="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ="
+  },
+  {
+    "pname": "runtime.any.System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-9EvnmZslLgLLhJ00o5MWaPuJQlbUFcUF8itGQNVkcQ4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-6MYj0RmLh4EVqMtO/MRqBi0HOn5iG4x9JimgCCJ+EFM="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Timer",
+    "version": "4.3.0",
+    "hash": "sha256-BgHxXCIbicVZtpgMimSXixhFC3V+p5ODqeljDjO8hCs="
+  },
+  {
+    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps="
+  },
+  {
+    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I="
+  },
+  {
+    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.native.System.IO.Compression",
+    "version": "4.3.0",
+    "hash": "sha256-DWnXs4vlKoU6WxxvCArTJupV6sX3iBbZh8SbqfHace8="
+  },
+  {
+    "pname": "runtime.native.System.Net.Http",
+    "version": "4.3.0",
+    "hash": "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.Apple",
+    "version": "4.3.0",
+    "hash": "sha256-2IhBv0i6pTcOyr8FFIyfPEaaCHUmJZ8DYwLUwJ+5waw="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
+  },
+  {
+    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM="
+  },
+  {
+    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+    "version": "4.3.0",
+    "hash": "sha256-serkd4A7F6eciPiPJtUyJyxzdAtupEcWIZQ9nptEzIM="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0="
+  },
+  {
+    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4="
+  },
+  {
+    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g="
+  },
+  {
+    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc="
+  },
+  {
+    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw="
+  },
+  {
+    "pname": "runtime.win.Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-ZnzR82+YDpNYf1GICTbzPjB20AjSy8dlRhfocK1FMEw="
+  },
+  {
+    "pname": "runtime.win.System.Console",
+    "version": "4.3.0",
+    "hash": "sha256-TCb+x4hHljj7sPIQLDsM10x5OyGZVnueYb+wlZ1UXnQ="
+  },
+  {
+    "pname": "runtime.win.System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-DpU+PGIUCtaK6gQEl/OWSO/JKg/TA9yeD01Zzxaxy5k="
+  },
+  {
+    "pname": "runtime.win.System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-6JnGF9kj6jYd9xneKQdTvb3zNTSHdeWW/pr7vui0AbA="
+  },
+  {
+    "pname": "runtime.win.System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-jqUpP60h/kkampLU9Bt8T5gSDaVXwxPsOOTEVVKAPbY="
+  },
+  {
+    "pname": "runtime.win.System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-k2lTk08ryI2NSEI3IFlO0y2cltiT8TIhNnqHgeL8I1M="
+  },
+  {
+    "pname": "runtime.win.System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-+TMflNyjP+Lf5bge0xVN5AKxMAk4/caWY6zZrqtyAJw="
+  },
+  {
+    "pname": "SixLabors.ImageSharp",
+    "version": "3.1.11",
+    "hash": "sha256-MlRF+3SGfahbsB1pZGKMOrsfUCx//hCo7ECrXr03DpA="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore",
+    "version": "6.6.2",
+    "hash": "sha256-kKz+NiXNfmrvrtbzsqnW1ItflNib3rymr3rf9yI5B1M="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.Swagger",
+    "version": "6.6.2",
+    "hash": "sha256-HqMmHMZXYHlRMoT3vIZF8iwhYmfknQmi3N8VmyfwI0k="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerGen",
+    "version": "6.6.2",
+    "hash": "sha256-km+bNoRDakEBa2dIjtxK0V6YVvm9hEpdi8xWQ8TJigI="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerUI",
+    "version": "6.6.2",
+    "hash": "sha256-ED24tUcwiOkAIMQVQeQFths296yf3lL/Z1sVizQTEHA="
+  },
+  {
+    "pname": "System.AppContext",
+    "version": "4.3.0",
+    "hash": "sha256-yg95LNQOwFlA1tWxXdQkVyJqT4AnoDc+ACmrNvzGiZg="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.3.0",
+    "hash": "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk="
+  },
+  {
+    "pname": "System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
+  },
+  {
+    "pname": "System.Collections.Concurrent",
+    "version": "4.3.0",
+    "hash": "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI="
+  },
+  {
+    "pname": "System.ComponentModel.Annotations",
+    "version": "5.0.0",
+    "hash": "sha256-0pST1UHgpeE6xJrYf5R+U7AwIlH3rVC3SpguilI/MAg="
+  },
+  {
+    "pname": "System.Console",
+    "version": "4.3.0",
+    "hash": "sha256-Xh3PPBZr0pDbDaK8AEHbdGz7ePK6Yi1ZyRWI1JM6mbo="
+  },
+  {
+    "pname": "System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "4.3.0",
+    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "6.0.0",
+    "hash": "sha256-zUXIQtAFKbiUMKCrXzO4mOTD5EUphZzghBYKXprowSM="
+  },
+  {
+    "pname": "System.Diagnostics.Tools",
+    "version": "4.3.0",
+    "hash": "sha256-gVOv1SK6Ape0FQhCVlNOd9cvQKBvMxRX9K0JPVi8w0Y="
+  },
+  {
+    "pname": "System.Diagnostics.Tracing",
+    "version": "4.3.0",
+    "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Globalization.Calendars",
+    "version": "4.3.0",
+    "hash": "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc="
+  },
+  {
+    "pname": "System.Globalization.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk="
+  },
+  {
+    "pname": "System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY="
+  },
+  {
+    "pname": "System.IO.Compression",
+    "version": "4.3.0",
+    "hash": "sha256-f5PrQlQgj5Xj2ZnHxXW8XiOivaBvfqDao9Sb6AVinyA="
+  },
+  {
+    "pname": "System.IO.Compression.ZipFile",
+    "version": "4.3.0",
+    "hash": "sha256-WQl+JgWs+GaRMeiahTFUbrhlXIHapzcpTFXbRvAtvvs="
+  },
+  {
+    "pname": "System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw="
+  },
+  {
+    "pname": "System.IO.FileSystem.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
+  },
+  {
+    "pname": "System.Linq",
+    "version": "4.3.0",
+    "hash": "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A="
+  },
+  {
+    "pname": "System.Linq.Expressions",
+    "version": "4.3.0",
+    "hash": "sha256-+3pvhZY7rip8HCbfdULzjlC9FPZFpYoQxhkcuFm2wk8="
+  },
+  {
+    "pname": "System.Net.Http",
+    "version": "4.3.0",
+    "hash": "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q="
+  },
+  {
+    "pname": "System.Net.NameResolution",
+    "version": "4.3.0",
+    "hash": "sha256-eGZwCBExWsnirWBHyp2sSSSXp6g7I6v53qNmwPgtJ5c="
+  },
+  {
+    "pname": "System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE="
+  },
+  {
+    "pname": "System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus="
+  },
+  {
+    "pname": "System.ObjectModel",
+    "version": "4.3.0",
+    "hash": "sha256-gtmRkWP2Kwr3nHtDh0yYtce38z1wrGzb6fjm4v8wN6Q="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.3.0",
+    "hash": "sha256-5LhkDmhy2FkSxulXR+bsTtMzdU3VyyuZzsxp7/DwyIU="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.3.0",
+    "hash": "sha256-mKRknEHNls4gkRwrEgi39B+vSaAz/Gt3IALtS98xNnA="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.3.0",
+    "hash": "sha256-rKx4a9yZKcajloSZHr4CKTVJ6Vjh95ni+zszPxWjh2I="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.7.0",
+    "hash": "sha256-V0Wz/UUoNIHdTGS9e1TR89u58zJjo/wPUWw6VaVyclU="
+  },
+  {
+    "pname": "System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "1.6.0",
+    "hash": "sha256-JJfgaPav7UfEh4yRAQdGhLZF1brr0tUWPl6qmfNWq/E="
+  },
+  {
+    "pname": "System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.3.0",
+    "hash": "sha256-4U4/XNQAnddgQIHIJq3P2T80hN0oPdU2uCeghsDTWng="
+  },
+  {
+    "pname": "System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o="
+  },
+  {
+    "pname": "System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms="
+  },
+  {
+    "pname": "System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI="
+  },
+  {
+    "pname": "System.Runtime.InteropServices.RuntimeInformation",
+    "version": "4.3.0",
+    "hash": "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA="
+  },
+  {
+    "pname": "System.Runtime.Numerics",
+    "version": "4.3.0",
+    "hash": "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc="
+  },
+  {
+    "pname": "System.Security.Claims",
+    "version": "4.3.0",
+    "hash": "sha256-Fua/rDwAqq4UByRVomAxMPmDBGd5eImRqHVQIeSxbks="
+  },
+  {
+    "pname": "System.Security.Cryptography.Algorithms",
+    "version": "4.3.0",
+    "hash": "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8="
+  },
+  {
+    "pname": "System.Security.Cryptography.Cng",
+    "version": "4.3.0",
+    "hash": "sha256-u17vy6wNhqok91SrVLno2M1EzLHZm6VMca85xbVChsw="
+  },
+  {
+    "pname": "System.Security.Cryptography.Csp",
+    "version": "4.3.0",
+    "hash": "sha256-oefdTU/Z2PWU9nlat8uiRDGq/PGZoSPRgkML11pmvPQ="
+  },
+  {
+    "pname": "System.Security.Cryptography.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss="
+  },
+  {
+    "pname": "System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-DL+D2sc2JrQiB4oAcUggTFyD8w3aLEjJfod5JPe+Oz4="
+  },
+  {
+    "pname": "System.Security.Cryptography.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318="
+  },
+  {
+    "pname": "System.Security.Cryptography.X509Certificates",
+    "version": "4.3.0",
+    "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
+  },
+  {
+    "pname": "System.Security.Principal",
+    "version": "4.3.0",
+    "hash": "sha256-rjudVUHdo8pNJg2EVEn0XxxwNo5h2EaYo+QboPkXlYk="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "4.3.0",
+    "hash": "sha256-mbdLVUcEwe78p3ZnB6jYsizNEqxMaCAWI3tEQNhRQAE="
+  },
+  {
+    "pname": "System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg="
+  },
+  {
+    "pname": "System.Text.Encoding.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc="
+  },
+  {
+    "pname": "System.Text.RegularExpressions",
+    "version": "4.3.0",
+    "hash": "sha256-VLCk1D1kcN2wbAe3d0YQM/PqCsPHOuqlBY1yd2Yo+K0="
+  },
+  {
+    "pname": "System.Threading",
+    "version": "4.3.0",
+    "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
+  },
+  {
+    "pname": "System.Threading.Overlapped",
+    "version": "4.3.0",
+    "hash": "sha256-tUX099CChkqWiHyP/1e4jGYzZAjgIthMOdMmiOGMUNk="
+  },
+  {
+    "pname": "System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-X2hQ5j+fxcmnm88Le/kSavjiGOmkcumBGTZKBLvorPc="
+  },
+  {
+    "pname": "System.Threading.Timer",
+    "version": "4.3.0",
+    "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
+  },
+  {
+    "pname": "System.Xml.ReaderWriter",
+    "version": "4.3.0",
+    "hash": "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA="
+  },
+  {
+    "pname": "System.Xml.XDocument",
+    "version": "4.3.0",
+    "hash": "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI="
+  },
+  {
+    "pname": "xunit",
+    "version": "2.5.3",
+    "hash": "sha256-X4TkN9y/572LnqOX+fiX6dqsqKe/HbAWZq6PhdD0qGM="
+  },
+  {
+    "pname": "xunit.abstractions",
+    "version": "2.0.3",
+    "hash": "sha256-0D1y/C34iARI96gb3bAOG8tcGPMjx+fMabTPpydGlAM="
+  },
+  {
+    "pname": "xunit.analyzers",
+    "version": "1.4.0",
+    "hash": "sha256-2m8ikSNvEzQ53rtqhruTpQZpJ+nzI9lhLj0x9w5FKO0="
+  },
+  {
+    "pname": "xunit.assert",
+    "version": "2.5.3",
+    "hash": "sha256-+cbNHWwm1no316xMJsdzO7TAV7bIlm3dz8dvKHQ66CU="
+  },
+  {
+    "pname": "xunit.core",
+    "version": "2.5.3",
+    "hash": "sha256-TEL6tBUxWDU9rVOj4KaxBpL+uZQ/3kcZWVDDueeQkhw="
+  },
+  {
+    "pname": "xunit.extensibility.core",
+    "version": "2.5.3",
+    "hash": "sha256-IjyXgVi/AAnilPsD4IrnqtSrr7Ugu75DguPnI2bVSFs="
+  },
+  {
+    "pname": "xunit.extensibility.execution",
+    "version": "2.5.3",
+    "hash": "sha256-zN7R4kZGsujpo8aAn4OHdtA0u/r5aeiZaw6A53B69KU="
+  },
+  {
+    "pname": "xunit.runner.visualstudio",
+    "version": "2.5.3",
+    "hash": "sha256-GZN1E9rOGorQvVSbGTsmXgJxj2TtJwJxCuo+oh+NEBI="
+  }
+]


### PR DESCRIPTION
- This PR adds nix building support to the project, allowing for linux users to build the windows executable, and run it within WINE. It additionally is for reproducible builds, ensuring the quality of all built artifacts. 
- The nix build succeeds end-to-end and the program does work in WINE, albeit without testing on a real Vidar scanner yet, but this can be future work in a future PR if changes are necessary. 
- We additionally lock the nuget dependencies with nix to ensure proper nix dependencies for the build.
- The config file location was changed due to the fact that the nix-store is read only, so the program is not allowed to add configuration files to it once it has been built, additionally, it is bad practice to edit the application directory outside of the installer.